### PR TITLE
[docs] 상대 경로 참조를 절대 경로 참조로 변경

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import "./App.css";
-import Router from "./components/Router";
+import Router from "components/Router";
 
 function App() {
   return (

--- a/src/components/Router.tsx
+++ b/src/components/Router.tsx
@@ -1,29 +1,27 @@
 import { Navigate, Route, Routes } from "react-router-dom";
-import Home from "../pages/home";
-import PostList from "../pages/posts";
-import PostDetail from "../pages/posts/detail";
-import PostNew from "../pages/posts/new";
-import PostEdit from "../pages/posts/edit";
-import Profile from "../pages/profile";
-import LoginPage from "../pages/login";
-import SignupPage from "../pages/signup";
+import Home from "pages/home";
+import PostList from "pages/posts";
+import PostDetail from "pages/posts/detail";
+import PostNew from "pages/posts/new";
+import PostEdit from "pages/posts/edit";
+import Profile from "pages/profile";
+import LoginPage from "pages/login";
+import SignupPage from "pages/signup";
 
 export default function Router() {
-    return (
-      <>
-        <Routes>
-          <Route path="/" element={<Home />} />
-          <Route path="/posts" element={<PostList />} />
-          <Route path="/posts/:id" element={<PostDetail />} />
-          <Route path="/posts/new" element={<PostNew />} />
-          <Route path="/posts/edit" element={<PostEdit />} />
-          <Route path="/profile" element={<Profile />} />
-          <Route path="/login" element={<LoginPage />} />
-          <Route path="/singup" element={<SignupPage />} />
-          <Route path="*" element={<Navigate replace to="/" />} />
-        </Routes>
-      </>
-    );
-  }
-  
-  
+  return (
+    <>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/posts" element={<PostList />} />
+        <Route path="/posts/:id" element={<PostDetail />} />
+        <Route path="/posts/new" element={<PostNew />} />
+        <Route path="/posts/edit" element={<PostEdit />} />
+        <Route path="/profile" element={<Profile />} />
+        <Route path="/login" element={<LoginPage />} />
+        <Route path="/singup" element={<SignupPage />} />
+        <Route path="*" element={<Navigate replace to="/" />} />
+      </Routes>
+    </>
+  );
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,17 +1,16 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import './index.css';
-import App from './App';
-import { BrowserRouter as Router } from 'react-router-dom';
+import React from "react";
+import ReactDOM from "react-dom/client";
+import "./index.css";
+import App from "./App";
+import { BrowserRouter as Router } from "react-router-dom";
 
 const root = ReactDOM.createRoot(
-  document.getElementById('root') as HTMLElement
+  document.getElementById("root") as HTMLElement
 );
 root.render(
   <React.StrictMode>
-    <Router >
-    <App />
+    <Router>
+      <App />
     </Router>
   </React.StrictMode>
 );
-

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -1,15 +1,12 @@
-import { Link } from "react-router-dom";
-import Header from "../../components/Header";
-import Footer from "../../components/Footer";
-import PostList from "../../components/PostList";
+import Header from "components/Header";
+import Footer from "components/Footer";
+import PostList from "components/PostList";
 
 export default function Home() {
   return (
     <div>
       <Header />
-
       <PostList />
-
       <Footer />
     </div>
   );

--- a/src/pages/posts/detail.tsx
+++ b/src/pages/posts/detail.tsx
@@ -1,6 +1,6 @@
-import Footer from "../../components/Footer";
-import Header from "../../components/Header";
-import PostDetail from "../../components/PostDetail";
+import Footer from "components/Footer";
+import Header from "components/Header";
+import PostDetail from "components/PostDetail";
 
 export default function PostPage() {
   return (

--- a/src/pages/posts/edit.tsx
+++ b/src/pages/posts/edit.tsx
@@ -1,6 +1,6 @@
-import Footer from "../../components/Footer";
-import Header from "../../components/Header";
-import PostEdit from "../../components/PostEdit";
+import Footer from "components/Footer";
+import Header from "components/Header";
+import PostEdit from "components/PostEdit";
 
 export default function PostEditPage() {
   return (

--- a/src/pages/posts/index.tsx
+++ b/src/pages/posts/index.tsx
@@ -1,6 +1,6 @@
-import Footer from "../../components/Footer";
-import Header from "../../components/Header";
-import PostList from "../../components/PostList";
+import Footer from "components/Footer";
+import Header from "components/Header";
+import PostList from "components/PostList";
 
 export default function PostListPage() {
   return (

--- a/src/pages/posts/new.tsx
+++ b/src/pages/posts/new.tsx
@@ -1,6 +1,6 @@
-import Footer from "../../components/Footer";
-import Header from "../../components/Header";
-import PostNew from "../../components/PostNew";
+import Footer from "components/Footer";
+import Header from "components/Header";
+import PostNew from "components/PostNew";
 
 export default function PostNewPage() {
   return (

--- a/src/pages/profile/index.tsx
+++ b/src/pages/profile/index.tsx
@@ -1,7 +1,7 @@
-import Footer from "../../components/Footer";
-import Header from "../../components/Header";
-import PostList from "../../components/PostList";
-import Profile from "../../components/Profile";
+import Footer from "components/Footer";
+import Header from "components/Header";
+import PostList from "components/PostList";
+import Profile from "components/Profile";
 
 export default function ProfilePage() {
   return (

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,8 @@
 {
   "compilerOptions": {
+    "baseUrl": "src", //절대 경로 기준
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -20,7 +17,9 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"],
+  "path": {
+    "pages/*": ["pages/*"],
+    "components/*": ["components/*"]
+  }
 }


### PR DESCRIPTION
`tsconfig.json` 파일에
-    "baseUrl": "src", //절대 경로 기준
-   "path": {
    "pages/*": ["pages/*"],
    "components/*": ["components/*"]
  }
추가하여 상대 경로로 참조하던 걸 절대경로로 참조하도록 변경

(변경 전) import PostDetail from "../../components/PostDetail";
(변경 후) import PostDetail from "components/PostDetail";
